### PR TITLE
Add connection and query timeout configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ akka-persistence-sql-async {
   metadata-table-name = "persistence_metadata"
   journal-table-name = "persistence_journal"
   snapshot-table-name = "persistence_snapshot"
+  
+  connect-timeout = 5s
+  query-timeout = 5s
 }
 ```
 

--- a/core/src/main/scala/akka/persistence/common/SQLAsyncConfig.scala
+++ b/core/src/main/scala/akka/persistence/common/SQLAsyncConfig.scala
@@ -1,6 +1,10 @@
 package akka.persistence.common
 
+import java.util.concurrent.TimeUnit
+
 import akka.actor.ActorSystem
+
+import scala.concurrent.duration._
 
 private[persistence] class SQLAsyncConfig(val system: ActorSystem) {
   val rootKey = "akka-persistence-sql-async"
@@ -15,6 +19,16 @@ private[persistence] class SQLAsyncConfig(val system: ActorSystem) {
   val metadataTableName = config.getString("metadata-table-name")
   val journalTableName = config.getString("journal-table-name")
   val snapshotTableName = config.getString("snapshot-table-name")
+
+  val connectTimeout: Option[Duration] = getOptionalDuration("connect-timeout", 5.seconds)
+  val queryTimeout: Option[Duration] = getOptionalDuration("query-timeout", 5.seconds)
+
+  private def getOptionalDuration(configKey: String, defaultValue: FiniteDuration) = {
+    if (config.hasPath(configKey))
+      Option(FiniteDuration(config.getDuration(configKey, TimeUnit.NANOSECONDS), TimeUnit.NANOSECONDS))
+    else
+      Option(defaultValue)
+  }
 }
 
 private[persistence] object SQLAsyncConfig {

--- a/core/src/main/scala/akka/persistence/common/ScalikeJDBCExtension.scala
+++ b/core/src/main/scala/akka/persistence/common/ScalikeJDBCExtension.scala
@@ -1,7 +1,7 @@
 package akka.persistence.common
 
 import akka.actor.{ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider}
-import scalikejdbc.async.{AsyncConnectionPool, AsyncConnectionPoolSettings}
+import scalikejdbc.async.{AsyncConnectionPool, AsyncConnectionPoolSettings, AsyncConnectionSettings}
 
 private[persistence] object ScalikeJDBCExtension extends ExtensionId[ScalikeJDBCExtension] with ExtensionIdProvider {
   override def createExtension(system: ExtendedActorSystem): ScalikeJDBCExtension = {
@@ -24,6 +24,11 @@ private[persistence] class ScalikeJDBCExtension(system: ExtendedActorSystem) ext
     password = if (config.password == "") null else config.password,
     settings = AsyncConnectionPoolSettings(
       maxPoolSize = config.maxPoolSize,
-      maxQueueSize = config.waitQueueCapacity)
+      maxQueueSize = config.waitQueueCapacity,
+      connectionSettings = AsyncConnectionSettings(
+        connectTimeout = config.connectTimeout,
+        queryTimeout = config.queryTimeout
+      )
+    )
   )
 }


### PR DESCRIPTION
Hi! 
In this PR I have added 2 new configurations: `connect-timeout` and `query-timeout `, both with default value of 5 seconds. 

Each setting allow the user to change the default value that is defined in `com.github.mauricio.async.db.Configuration` . 

Best regards and thanks for your work! 