### PR TITLE
duplicate key value violates unique constraint "persistence_snapshot_pkey"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jdk:
   - oraclejdk8
 
 addons:
-  postgresql: "9.3"
+  postgresql: "9.6"
 
 before_script:
   - psql -c "CREATE ROLE root WITH SUPERUSER LOGIN PASSWORD '';" -U postgres

--- a/core/src/main/scala/akka/persistence/journal/sqlasync/SQLAsyncWriteJournal.scala
+++ b/core/src/main/scala/akka/persistence/journal/sqlasync/SQLAsyncWriteJournal.scala
@@ -34,7 +34,7 @@ class PostgreSQLAsyncWriteJournal extends ScalikeJDBCWriteJournal with PostgreSQ
   override protected[this] def updateSequenceNr(persistenceId: String, sequenceNr: Long)(
       implicit session: TxAsyncDBSession): Future[Unit] = {
     val sql =
-      sql"WITH upsert AS (UPDATE $metadataTable SET sequence_nr = $sequenceNr WHERE persistence_id = $persistenceId RETURNING *) INSERT INTO $metadataTable (persistence_id, sequence_nr) SELECT $persistenceId, $sequenceNr WHERE NOT EXISTS (SELECT * FROM upsert)"
+      sql"INSERT INTO $metadataTable (persistence_id, sequence_nr) VALUES ($persistenceId, $sequenceNr) ON CONFLICT (persistence_id) DO UPDATE SET sequence_nr = $sequenceNr"
     logging(sql).update().future().map(_ => ())
   }
 }

--- a/core/src/main/scala/akka/persistence/snapshot/sqlasync/SQLAsyncSnapshotStore.scala
+++ b/core/src/main/scala/akka/persistence/snapshot/sqlasync/SQLAsyncSnapshotStore.scala
@@ -44,7 +44,7 @@ class PostgreSQLSnapshotStore extends ScalikeJDBCSnapshotStore with PostgreSQLPl
     sessionProvider.localTx { implicit session =>
       for {
         key <- surrogateKeyOf(persistenceId)
-        sql = sql"WITH upsert AS (UPDATE $snapshotTable SET created_at = $timestamp, snapshot = $snapshot WHERE persistence_key = $key AND sequence_nr = $sequenceNr RETURNING *) INSERT INTO $snapshotTable (persistence_key, sequence_nr, created_at, snapshot) SELECT $key, $sequenceNr, $timestamp, $snapshot WHERE NOT EXISTS (SELECT * FROM upsert)"
+        sql = sql"INSERT INTO $snapshotTable (persistence_key, sequence_nr, created_at, snapshot) VALUES ($key, $sequenceNr, $timestamp, $snapshot) ON CONFLICT (persistence_key, sequence_nr) DO UPDATE SET created_at = $timestamp, snapshot = $snapshot"
         _ <- logging(sql).update().future()
       } yield ()
     }


### PR DESCRIPTION
"Trying to update the same row twice in a single statement is not supported. Only one of the modifications takes place, but it is not easy (and sometimes not possible) to reliably predict which one. This also applies to deleting a row that was already updated in the same statement: only the update is performed. Therefore you should generally avoid trying to modify a single row twice in a single statement. In particular avoid writing WITH sub-statements that could affect the same rows changed by the main statement or a sibling sub-statement. The effects of such a statement will not be predictable."

https://www.postgresql.org/docs/9.6/static/queries-with.html

2018-07-25 07:34:02.881 +0000 [application-akka.actor.default-dispatcher-244] ERROR  - PersistentActor: Failed to save snapshot SnapshotMetadata(key,584853,0)
com.github.mauricio.async.db.postgresql.exceptions.GenericDatabaseException: ErrorMessage(fields=Map(Detail -> Key (persistence_key, sequence_nr)=(3, 584853) already exists., s -> public, n -> persistence_snapshot_pkey, t -> persistence_snapshot, Line -> 433, File -> nbtinsert.c, SQLSTATE -> 23505, Routine -> _bt_check_unique, V -> ERROR, Message -> duplicate key value violates unique constraint "persistence_snapshot_pkey", Severity -> ERROR))
        at com.github.mauricio.async.db.postgresql.PostgreSQLConnection.onError(PostgreSQLConnection.scala:175)
        at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:105)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340)
        at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:310)
        at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:297)
        at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:413)
        at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:265)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340)
        at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1414)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
        at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:945)
        at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:146)
        at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:645)
        at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:580)
        at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:497)
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:459)
        at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:886)
        at java.lang.Thread.run(Unknown Source)